### PR TITLE
[SHIP] docs: README 프로젝트 구조 섹션 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ***REMOVED***
+# lifepuzzle-rn
 
 ### Get Started
 
@@ -10,23 +10,25 @@ npm run ios:prod # iOS 실행
 
 ### Structure of `app` Folder
 
-- assets : 이미지, 폰트 등 에셋
-  - fonts
-  - images
-- components : 화면(Page)에서 사용되는 컴포넌트
-- constants : B/E API URL 등 전역 상수
-- navigation : navigation(화면간 이동) 설정
-- pages : 화면들
-  - Foo
-    - FooPage.tsx
-    - style.tsx
-  - ...
-- recoils : recoil(전역 상태 관리 툴) 설정
-- service : 비지니스 로직(화면 표현을 위한 디자인, 레이아웃 외 로직) 담당 레이어
-  - hooks : 커스텀 훅
-  - foo.service.ts
-  - ...
-- types : 전역 Typescript 타입
+```
+app/
+├── app.tsx                   # 앱 엔트리 포인트
+├── assets/                   # 정적 자산 (이미지, 폰트, 아이콘)
+│   ├── fonts/               # 폰트 파일
+│   ├── icons/               # SVG 아이콘들
+│   └── images/              # 이미지 파일
+├── components/              # 재사용 가능한 UI 컴포넌트들
+├── constants/               # 전역 상수 (API URL, 색상 등)
+├── navigation/              # 화면 간 이동을 위한 네비게이션 설정
+│   ├── home-tab/           # 탭 네비게이션
+│   └── no-tab/             # 스택 네비게이션
+├── pages/                   # 각 화면을 담당하는 페이지 컴포넌트
+├── recoils/                # Recoil을 이용한 전역 상태 관리
+├── service/                # 비즈니스 로직 및 API 호출 로직
+│   └── hooks/              # 커스텀 훅
+├── types/                  # TypeScript 타입 정의
+└── utils/                  # 공통 유틸리티 함수
+```
 
 ### Development Guide
 


### PR DESCRIPTION
작업 배경

- README 파일의 프로젝트 구조 섹션이 현재 실제 프로젝트 구조와 맞지 않음
- 기존 목록 형태보다 트리 구조가 더 직관적이고 이해하기 쉬움

작업 내용

- `Structure of app Folder` 섹션을 현재 프로젝트 구조에 맞게 업데이트
- 기존 목록 형태에서 트리 구조로 변경하여 가독성 향상
- 각 폴더에 대한 간략한 설명을 주석으로 추가
- utils 폴더 등 누락된 디렉토리 추가

참고 사항

- 기존 README의 다른 섹션은 변경하지 않음
- 마크다운 문법이 올바르게 렌더링되는지 확인 완료

🤖 Generated with [Claude Code](https://claude.ai/code)