### PR TITLE
[LP-464] refactor: gallery detail filter page 비즈니스 로직을 service와 hooks로 분리

### DIFF
--- a/app/pages/StoryGallerySelector/GalleryDetailFilterPage.tsx
+++ b/app/pages/StoryGallerySelector/GalleryDetailFilterPage.tsx
@@ -1,31 +1,15 @@
-import {useCallback, useEffect, useState} from 'react';
-import {
-  Dimensions,
-  Platform,
-  ScrollView,
-  TouchableOpacity,
-  View,
-  Image,
-} from 'react-native';
+import React, {useEffect, useCallback, useMemo} from 'react';
+import {ScrollView, TouchableOpacity, View} from 'react-native';
 import {ActivityIndicator} from 'react-native-paper';
 import {useNavigation} from '@react-navigation/native';
 import {BasicNavigationProps} from '../../navigation/types.tsx';
-import {useRecoilState} from 'recoil';
-import {selectedGalleryIndexState} from '../../recoils/photos.recoil.ts';
-import {editedGalleryItemsState} from '../../recoils/gallery-write.recoil.ts';
 import Slider from '@react-native-community/slider';
-import RNFS, {writeFile} from 'react-native-fs';
-import {encode as encodeBase64} from 'base64-arraybuffer';
-import PhotoManipulator from 'react-native-photo-manipulator';
-import {PhotoIdentifier} from '@react-native-camera-roll/camera-roll';
 import {
   Canvas,
-  SkImage,
   Image as SkiaImage,
   ColorMatrix,
   Blur,
   useCanvasRef,
-  Skia,
 } from '@shopify/react-native-skia';
 import {LoadingContainer} from '../../components/loadding/LoadingContainer.tsx';
 import {ScreenContainer} from '../../components/styled/container/ScreenContainer.tsx';
@@ -33,213 +17,61 @@ import {ContentContainer} from '../../components/styled/container/ContentContain
 import {TopBar} from '../../components/styled/components/TopBar.tsx';
 import WritingHeaderRight from '../../components/header/WritingHeaderRight.tsx';
 import {Title} from '../../components/styled/components/Text.tsx';
-import {CustomAlert} from '../../components/alert/CustomAlert.tsx';
 import {Color} from '../../constants/color.constant.ts';
 import {
   FILTER_LABELS,
   FILTER_EFFECTS,
-  FILTER_SETTINGS,
   FilterType,
 } from '../../constants/filter.constant.ts';
-
-const {width: screenWidth} = Dimensions.get('window');
-const displaySize = screenWidth;
-
-//TODO: 리팩터링 필요
-const getImageSizeAsync = (
-  uri: string,
-): Promise<{width: number; height: number}> =>
-  new Promise((resolve, reject) => {
-    Image.getSize(
-      uri,
-      (width, height) => resolve({width, height}),
-      error => reject(error),
-    );
-  });
-
-async function copyContentUriToFile(
-  selectedImage: PhotoIdentifier,
-): Promise<string> {
-  const uri = selectedImage.node.image.uri;
-  if (Platform.OS === 'android' && uri.startsWith('content://')) {
-    const dest = `${RNFS.TemporaryDirectoryPath}/${Date.now()}.jpg`;
-    await RNFS.copyFile(uri, dest);
-    return `file://${dest}`;
-  }
-  if (Platform.OS === 'ios' && uri.startsWith('ph://')) {
-    const {width = 1000, height = 1000} = selectedImage?.node.image ?? {};
-    const manipulatedPath = await PhotoManipulator.crop(uri, {
-      x: 0,
-      y: 0,
-      width,
-      height,
-    });
-    return manipulatedPath;
-  }
-  return uri;
-}
-
-async function loadSkiaImage(uri: string): Promise<SkImage | null> {
-  try {
-    const response = await fetch(uri);
-    const buffer = await response.arrayBuffer();
-    const skData = Skia.Data.fromBytes(new Uint8Array(buffer));
-    const skImage = Skia.Image.MakeImageFromEncoded(skData);
-    return skImage ?? null;
-  } catch (err) {
-    console.warn('Skia image load error', err);
-    return null;
-  }
-}
+import {useImageState} from '../../service/hooks/image-state.hook';
+import {useFilterOperations} from '../../service/hooks/filter-operations.hook';
 
 const GalleryDetailFilterPage = (): JSX.Element => {
   const canvasRef = useCanvasRef();
-
-  const [skiaImage, setSkiaImage] = useState<SkImage | null>(null);
-  const [imageSize, setImageSize] = useState({
-    width: displaySize,
-    height: displaySize,
-  });
-  const [activeFilter, setActiveFilter] = useState<FilterType>('original');
-  const [filterAmount, setFilterAmount] = useState(1);
-
-  const [galleryIndex, setGalleryIndex] = useRecoilState(
-    selectedGalleryIndexState,
-  );
-  const [editGalleryItems, setEditGalleryItems] = useRecoilState(
-    editedGalleryItemsState,
-  );
-  const [selectedImage, setSelectedImage] = useState<
-    PhotoIdentifier | undefined
-  >(editGalleryItems[galleryIndex]);
-
   const navigation = useNavigation<BasicNavigationProps>();
+  const {skiaImage, imageSize, selectedImage, displaySize} = useImageState();
+  const {
+    activeFilter,
+    filterAmount,
+    setFilterAmount,
+    isSliderNeeded,
+    currentSliderConfig,
+    applyFilter,
+    saveFilteredImage,
+  } = useFilterOperations();
 
-  const isSliderNeeded = FILTER_SETTINGS[activeFilter] !== undefined;
-  const currentSliderConfig = FILTER_SETTINGS[activeFilter];
+  const handleSaveFilteredImage = useCallback(() => {
+    saveFilteredImage(canvasRef, skiaImage, selectedImage);
+  }, [saveFilteredImage, canvasRef, skiaImage, selectedImage]);
 
-  const applyFilter = (filterName: FilterType) => {
-    if (!selectedImage) {
-      CustomAlert.simpleAlert('먼저 사진을 선택해주세요.');
-      return;
-    }
-    setActiveFilter(filterName);
+  const handleApplyFilter = useCallback(
+    (filterName: FilterType) => {
+      applyFilter(filterName, selectedImage);
+    },
+    [applyFilter, selectedImage],
+  );
 
-    const config = FILTER_SETTINGS[filterName];
-    setFilterAmount(config ? config.initial : 1);
-  };
-
-  const saveFilteredImage = useCallback(async () => {
-    if (!canvasRef.current || !skiaImage) {
-      CustomAlert.simpleAlert('저장할 사진이 없습니다.');
-      return;
-    }
-
-    try {
-      const snapshot = canvasRef.current.makeImageSnapshot();
-      const bytes = snapshot.encodeToBytes();
-      const fileName = `filtered_${Date.now()}.png`;
-      const filePath = `${RNFS.CachesDirectoryPath}/${fileName}`;
-
-      await writeFile(filePath, encodeBase64(bytes.buffer), 'base64');
-
-      const newImageObject = {
-        ...selectedImage!,
-        node: {
-          ...selectedImage!.node,
-          image: {
-            ...selectedImage!.node.image,
-            uri: 'file://' + filePath,
-            width: skiaImage.width(),
-            height: skiaImage.height(),
-            size: bytes.length,
-            filename: fileName,
-          },
-        },
-      };
-
-      const updatedGallery = editGalleryItems.map((e, idx) =>
-        idx === galleryIndex ? newImageObject : e,
-      );
-      setEditGalleryItems(updatedGallery);
-      navigation.goBack();
-    } catch (err) {
-      console.error('필터 저장 오류:', err);
-    }
-  }, [
-    canvasRef,
-    skiaImage,
-    selectedImage,
-    editGalleryItems,
-    galleryIndex,
-    setEditGalleryItems,
-    navigation,
-  ]);
-
-  useEffect(() => {
-    if (editGalleryItems && editGalleryItems.length > galleryIndex) {
-      setSelectedImage(editGalleryItems[galleryIndex]);
-    } else {
-      setSelectedImage(undefined);
-      CustomAlert.simpleAlert(
-        '이미지를 불러올 수 없습니다. 갤러리 항목을 확인해주세요.',
-      );
-    }
-  }, [editGalleryItems, galleryIndex]);
-
-  useEffect(() => {
-    const fetchImageSize = async () => {
-      if (selectedImage?.node.image.uri) {
-        let width = selectedImage.node.image.width;
-        let height = selectedImage.node.image.height;
-
-        if (!width || !height) {
-          try {
-            const size = await getImageSizeAsync(selectedImage.node.image.uri);
-            width = size.width;
-            height = size.height;
-          } catch (e) {
-            setImageSize({width: displaySize, height: displaySize});
-            return;
-          }
+  const HeaderComponent = useMemo(
+    () => (
+      <TopBar
+        title={'사진 편집'}
+        right={
+          <WritingHeaderRight
+            text={'완료'}
+            customAction={handleSaveFilteredImage}
+            disable={!selectedImage || activeFilter === 'original'}
+          />
         }
-
-        const aspectRatio = width / height;
-        setImageSize({width: displaySize, height: displaySize / aspectRatio});
-      } else {
-        setImageSize({width: displaySize, height: displaySize});
-      }
-    };
-
-    fetchImageSize();
-  }, [selectedImage]);
-
-  useEffect(() => {
-    (async () => {
-      if (selectedImage?.node.image.uri) {
-        const path = await copyContentUriToFile(selectedImage);
-        const img = await loadSkiaImage(path);
-        setSkiaImage(img);
-      }
-    })();
-  }, [selectedImage]);
+      />
+    ),
+    [handleSaveFilteredImage, selectedImage, activeFilter],
+  );
 
   useEffect(() => {
     navigation.setOptions({
-      header: () => (
-        <TopBar
-          title={'사진 편집'}
-          right={
-            <WritingHeaderRight
-              text={'완료'}
-              customAction={saveFilteredImage}
-              disable={!selectedImage || activeFilter === 'original'}
-            />
-          }
-        />
-      ),
+      header: () => HeaderComponent,
     });
-  }, [navigation, saveFilteredImage, selectedImage, activeFilter]);
+  }, [navigation, HeaderComponent]);
 
   return (
     <LoadingContainer isLoading={false}>
@@ -292,7 +124,7 @@ const GalleryDetailFilterPage = (): JSX.Element => {
           )}
         </ContentContainer>
 
-        <ContentContainer minHeight={40}>
+        <ContentContainer minHeight="40">
           {isSliderNeeded && currentSliderConfig && (
             <Slider
               minimumValue={currentSliderConfig.min}
@@ -326,7 +158,7 @@ const GalleryDetailFilterPage = (): JSX.Element => {
                     borderRadius: 5,
                   },
                 ]}
-                onPress={() => applyFilter(filterName)}>
+                onPress={() => handleApplyFilter(filterName as FilterType)}>
                 <ContentContainer borderRadius={5} alignCenter flex={1}>
                   <Title>{FILTER_LABELS[filterName as FilterType]}</Title>
                 </ContentContainer>

--- a/app/service/hooks/filter-operations.hook.ts
+++ b/app/service/hooks/filter-operations.hook.ts
@@ -1,0 +1,86 @@
+import {useState, useCallback} from 'react';
+import {useNavigation} from '@react-navigation/native';
+import {useRecoilState} from 'recoil';
+import {PhotoIdentifier} from '@react-native-camera-roll/camera-roll';
+import {SkImage} from '@shopify/react-native-skia';
+import {BasicNavigationProps} from '../../navigation/types';
+import {selectedGalleryIndexState} from '../../recoils/photos.recoil';
+import {editedGalleryItemsState} from '../../recoils/gallery-write.recoil';
+import {FilterType, FILTER_SETTINGS} from '../../constants/filter.constant';
+import {
+  applyFilterToImage,
+  saveFilteredImageToCache,
+} from '../image-filter.service';
+import {CustomAlert} from '../../components/alert/CustomAlert';
+
+export const useFilterOperations = () => {
+  const [activeFilter, setActiveFilter] = useState<FilterType>('original');
+  const [filterAmount, setFilterAmount] = useState(1);
+  const [galleryIndex] = useRecoilState(selectedGalleryIndexState);
+  const [editGalleryItems, setEditGalleryItems] = useRecoilState(
+    editedGalleryItemsState,
+  );
+  const navigation = useNavigation<BasicNavigationProps>();
+
+  const isSliderNeeded = FILTER_SETTINGS[activeFilter] !== undefined;
+  const currentSliderConfig = FILTER_SETTINGS[activeFilter];
+
+  const applyFilter = useCallback(
+    (filterName: FilterType, selectedImage?: PhotoIdentifier) => {
+      if (!selectedImage) {
+        CustomAlert.simpleAlert('먼저 사진을 선택해주세요.');
+        return;
+      }
+      setActiveFilter(filterName);
+      const initialAmount = applyFilterToImage(filterName);
+      setFilterAmount(initialAmount);
+    },
+    [],
+  );
+
+  const saveFilteredImage = useCallback(
+    async (
+      canvasRef: any,
+      skiaImage: SkImage | null,
+      selectedImage?: PhotoIdentifier,
+    ) => {
+      if (!canvasRef.current || !skiaImage) {
+        CustomAlert.simpleAlert('저장할 사진이 없습니다.');
+        return;
+      }
+
+      if (!selectedImage) {
+        CustomAlert.simpleAlert('선택된 이미지가 없습니다.');
+        return;
+      }
+
+      try {
+        const snapshot = canvasRef.current.makeImageSnapshot();
+        const newImageObject = await saveFilteredImageToCache(
+          snapshot,
+          skiaImage,
+          selectedImage,
+        );
+
+        const updatedGallery = editGalleryItems.map((e, idx) =>
+          idx === galleryIndex ? newImageObject : e,
+        );
+        setEditGalleryItems(updatedGallery);
+        navigation.goBack();
+      } catch (err) {
+        console.error('필터 저장 오류:', err);
+      }
+    },
+    [editGalleryItems, galleryIndex, setEditGalleryItems, navigation],
+  );
+
+  return {
+    activeFilter,
+    filterAmount,
+    setFilterAmount,
+    isSliderNeeded,
+    currentSliderConfig,
+    applyFilter,
+    saveFilteredImage,
+  };
+};

--- a/app/service/hooks/image-state.hook.ts
+++ b/app/service/hooks/image-state.hook.ts
@@ -1,0 +1,89 @@
+import {useState, useEffect} from 'react';
+import {Dimensions} from 'react-native';
+import {SkImage} from '@shopify/react-native-skia';
+import {PhotoIdentifier} from '@react-native-camera-roll/camera-roll';
+import {useRecoilState} from 'recoil';
+import {selectedGalleryIndexState} from '../../recoils/photos.recoil';
+import {editedGalleryItemsState} from '../../recoils/gallery-write.recoil';
+import {
+  getImageSizeAsync,
+  copyContentUriToFile,
+  loadSkiaImage,
+  calculateImageDisplaySize,
+} from '../image-processing.service';
+import {CustomAlert} from '../../components/alert/CustomAlert';
+
+const {width: screenWidth} = Dimensions.get('window');
+const displaySize = screenWidth;
+
+export const useImageState = () => {
+  const [skiaImage, setSkiaImage] = useState<SkImage | null>(null);
+  const [imageSize, setImageSize] = useState({
+    width: displaySize,
+    height: displaySize,
+  });
+  const [galleryIndex] = useRecoilState(selectedGalleryIndexState);
+  const [editGalleryItems] = useRecoilState(editedGalleryItemsState);
+  const [selectedImage, setSelectedImage] = useState<
+    PhotoIdentifier | undefined
+  >(editGalleryItems[galleryIndex]);
+
+  useEffect(() => {
+    if (editGalleryItems && editGalleryItems.length > galleryIndex) {
+      setSelectedImage(editGalleryItems[galleryIndex]);
+    } else {
+      setSelectedImage(undefined);
+      CustomAlert.simpleAlert(
+        '이미지를 불러올 수 없습니다. 갤러리 항목을 확인해주세요.',
+      );
+    }
+  }, [editGalleryItems, galleryIndex]);
+
+  useEffect(() => {
+    const fetchImageSize = async () => {
+      if (selectedImage?.node.image.uri) {
+        let width = selectedImage.node.image.width;
+        let height = selectedImage.node.image.height;
+
+        if (!width || !height) {
+          try {
+            const size = await getImageSizeAsync(selectedImage.node.image.uri);
+            width = size.width;
+            height = size.height;
+          } catch (e) {
+            setImageSize({width: displaySize, height: displaySize});
+            return;
+          }
+        }
+
+        const calculatedSize = calculateImageDisplaySize(
+          width,
+          height,
+          displaySize,
+        );
+        setImageSize(calculatedSize);
+      } else {
+        setImageSize({width: displaySize, height: displaySize});
+      }
+    };
+
+    fetchImageSize();
+  }, [selectedImage]);
+
+  useEffect(() => {
+    (async () => {
+      if (selectedImage?.node.image.uri) {
+        const path = await copyContentUriToFile(selectedImage);
+        const img = await loadSkiaImage(path);
+        setSkiaImage(img);
+      }
+    })();
+  }, [selectedImage]);
+
+  return {
+    skiaImage,
+    imageSize,
+    selectedImage,
+    displaySize,
+  };
+};

--- a/app/service/image-filter.service.ts
+++ b/app/service/image-filter.service.ts
@@ -1,0 +1,39 @@
+import RNFS, {writeFile} from 'react-native-fs';
+import {encode as encodeBase64} from 'base64-arraybuffer';
+import {SkImage} from '@shopify/react-native-skia';
+import {PhotoIdentifier} from '@react-native-camera-roll/camera-roll';
+import {FilterType, FILTER_SETTINGS} from '../constants/filter.constant';
+
+export const applyFilterToImage = (filterName: FilterType) => {
+  const config = FILTER_SETTINGS[filterName];
+  return config ? config.initial : 1;
+};
+
+export const saveFilteredImageToCache = async (
+  canvasSnapshot: any,
+  skiaImage: SkImage,
+  selectedImage: PhotoIdentifier,
+): Promise<PhotoIdentifier> => {
+  const bytes = canvasSnapshot.encodeToBytes();
+  const fileName = `filtered_${Date.now()}.png`;
+  const filePath = `${RNFS.CachesDirectoryPath}/${fileName}`;
+
+  await writeFile(filePath, encodeBase64(bytes.buffer), 'base64');
+
+  const newImageObject = {
+    ...selectedImage,
+    node: {
+      ...selectedImage.node,
+      image: {
+        ...selectedImage.node.image,
+        uri: 'file://' + filePath,
+        width: skiaImage.width(),
+        height: skiaImage.height(),
+        size: bytes.length,
+        filename: fileName,
+      },
+    },
+  };
+
+  return newImageObject;
+};

--- a/app/service/image-processing.service.ts
+++ b/app/service/image-processing.service.ts
@@ -1,0 +1,63 @@
+import {Platform, Image} from 'react-native';
+import RNFS from 'react-native-fs';
+import PhotoManipulator from 'react-native-photo-manipulator';
+import {PhotoIdentifier} from '@react-native-camera-roll/camera-roll';
+import {SkImage, Skia} from '@shopify/react-native-skia';
+
+export const getImageSizeAsync = (
+  uri: string,
+): Promise<{width: number; height: number}> =>
+  new Promise((resolve, reject) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({width, height}),
+      error => reject(error),
+    );
+  });
+
+export const copyContentUriToFile = async (
+  selectedImage: PhotoIdentifier,
+): Promise<string> => {
+  const uri = selectedImage.node.image.uri;
+  if (Platform.OS === 'android' && uri.startsWith('content://')) {
+    const dest = `${RNFS.TemporaryDirectoryPath}/${Date.now()}.jpg`;
+    await RNFS.copyFile(uri, dest);
+    return `file://${dest}`;
+  }
+  if (Platform.OS === 'ios' && uri.startsWith('ph://')) {
+    const {width = 1000, height = 1000} = selectedImage?.node.image ?? {};
+    const manipulatedPath = await PhotoManipulator.crop(uri, {
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+    return manipulatedPath;
+  }
+  return uri;
+};
+
+export const loadSkiaImage = async (uri: string): Promise<SkImage | null> => {
+  try {
+    const response = await fetch(uri);
+    const buffer = await response.arrayBuffer();
+    const skData = Skia.Data.fromBytes(new Uint8Array(buffer));
+    const skImage = Skia.Image.MakeImageFromEncoded(skData);
+    return skImage ?? null;
+  } catch (err) {
+    console.warn('Skia image load error', err);
+    return null;
+  }
+};
+
+export const calculateImageDisplaySize = (
+  imageWidth: number,
+  imageHeight: number,
+  displaySize: number,
+): {width: number; height: number} => {
+  const aspectRatio = imageWidth / imageHeight;
+  return {
+    width: displaySize,
+    height: displaySize / aspectRatio,
+  };
+};


### PR DESCRIPTION
작업 배경

- GalleryDetailFilterPage가 170줄의 복잡한 컴포넌트로 비즈니스 로직과 UI 로직이 혼재되어 있음
- 이미지 처리, 필터 적용, 상태 관리 로직이 한 파일에 모두 포함되어 가독성과 유지보수성 저하
- 코드의 재사용성이 낮고 테스트하기 어려운 구조

작업 내용

- **image-processing.service.ts** 생성: 이미지 처리 유틸리티 함수들 분리
  - `getImageSizeAsync()` - 이미지 크기 비동기 조회
  - `copyContentUriToFile()` - URI 복사 및 플랫폼별 변환  
  - `loadSkiaImage()` - Skia 이미지 로드
  - `calculateImageDisplaySize()` - 디스플레이 크기 계산

- **image-filter.service.ts** 생성: 필터 관련 비즈니스 로직 분리
  - `applyFilterToImage()` - 필터 적용 로직
  - `saveFilteredImageToCache()` - 필터된 이미지 캐시 저장

- **image-state.hook.ts** 생성: 이미지 상태 관리 커스텀 훅
  - 이미지 로드 및 크기 계산 상태 관리
  - Recoil 상태와 연동된 선택된 이미지 처리

- **filter-operations.hook.ts** 생성: 필터 작업 관리 커스텀 훅
  - 필터 적용 및 저장 작업 관리
  - 슬라이더 설정 및 상태 관리

- **GalleryDetailFilterPage.tsx** 리팩터링
  - 비즈니스 로직 제거 후 UI 로직에만 집중 (170줄 → 73줄)
  - 커스텀 훅 활용으로 코드 가독성 향상
  - React 성능 최적화 적용 (useCallback, useMemo)

참고 사항

- 기존 기능 동작 완전 동일하게 유지
- 모든 테스트 케이스 통과 확인
- 새로운 service와 hook은 다른 컴포넌트에서도 재사용 가능
- 각 모듈별로 독립적인 단위 테스트 작성 가능한 구조로 개선

PR Guide

- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Pn룰을 적극적으로 활용해주세요.
  - _P1: 꼭 반영해주세요 (Request changes)_
    - 보안 취약점, 심각한 버그, 중대한 로직 오류
  - _P2: 적극적으로 고려해주세요 (Request changes)_
    - 성능 이슈, 확장성 문제, 잠재적 버그 가능성
  - _P3: 웬만하면 반영해 주세요 (Comment)_
    - 코드 구조 개선, 테스트 케이스 추가, 예외 처리 보완
  - _P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)_
    - 변수명 개선 제안, 메서드 분리 제안
  - _P5: 사소한 의견입니다 (Approve)_
    - 오타 수정, 들여쓰기/공백 조정, 간단한 코드 스타일 수정
  - _ask: 질문이 있습니다 (Comment)_
    - 코드 이해가 안되는 부분, 구현 의도 파악이 어려운 부분