### PR TITLE
refactor: JWT exp 클레임 기반 토큰 만료 시간 처리로 변경

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -35,11 +35,7 @@ const theme = {
 function initializeRecoilState({set}: MutableSnapshot): void {
   const authToken = LocalStorage.get('authToken', 'json');
   if (authToken) {
-    set(authState, {
-      ...authToken,
-      accessTokenExpireAt: new Date(authToken.accessTokenExpireAt),
-      refreshTokenExpireAt: new Date(authToken.refreshTokenExpireAt),
-    });
+    set(authState, authToken);
   }
 }
 

--- a/app/recoils/auth.recoil.ts
+++ b/app/recoils/auth.recoil.ts
@@ -1,13 +1,12 @@
 import {atom, selector} from 'recoil';
 import {AuthTokens} from '../types/auth.type';
+import {getTokenState} from '../service/auth.service';
 
 export const authState = atom<AuthTokens>({
   key: 'authState',
   default: {
     accessToken: '',
-    accessTokenExpireAt: new Date(),
     refreshToken: '',
-    refreshTokenExpireAt: new Date(),
   },
 });
 
@@ -15,20 +14,11 @@ export const isLoggedInState = selector({
   key: 'loginState',
   get: ({get}) => {
     const auth = get(authState);
-    if (!auth) {
+    if (!auth || !auth.accessToken) {
       return false;
     }
 
-    const accessTokenExpireAt =
-      auth.accessTokenExpireAt instanceof Date
-        ? auth.accessTokenExpireAt
-        : Date.parse(auth.accessTokenExpireAt);
-    const refreshTokenExpireAt =
-      auth.refreshTokenExpireAt instanceof Date
-        ? auth.refreshTokenExpireAt
-        : Date.parse(auth.refreshTokenExpireAt);
-    const current = Date.now();
-
-    return refreshTokenExpireAt >= current || accessTokenExpireAt >= current;
+    const tokenState = getTokenState(auth);
+    return tokenState !== 'Expire';
   },
 });

--- a/app/service/auth.service.test.ts
+++ b/app/service/auth.service.test.ts
@@ -1,14 +1,20 @@
 import {getTokenState} from './auth.service';
 import {AuthTokens} from '../types/auth.type';
 
+// Mock JWT tokens for testing
+const createMockToken = (exp: number): string => {
+  const header = btoa(JSON.stringify({alg: 'HS256', typ: 'JWT'}));
+  const payload = btoa(JSON.stringify({exp}));
+  const signature = 'mock-signature';
+  return `${header}.${payload}.${signature}`;
+};
+
 test.each(['', undefined, null])(
   'access token이 없는 경우 Expire를 반환한다.',
   accessToken => {
     const result = getTokenState(<AuthTokens>{
       accessToken: accessToken,
-      accessTokenExpireAt: new Date(),
       refreshToken: 'refresh-token',
-      refreshTokenExpireAt: new Date(),
     });
 
     expect(result).toBe('Expire');
@@ -16,39 +22,43 @@ test.each(['', undefined, null])(
 );
 
 test('access token과 refesh token이 모두 만료한 경우 Expire를 반환한다.', () => {
-  const justBefore = new Date(Date.now() - 1);
+  const expiredTime = Math.floor(Date.now() / 1000) - 1; // 1초 전 만료
+  const expiredAccessToken = createMockToken(expiredTime);
+  const expiredRefreshToken = createMockToken(expiredTime);
+
   const result = getTokenState({
-    accessToken: 'access-token',
-    accessTokenExpireAt: justBefore,
-    refreshToken: 'refresh-token',
-    refreshTokenExpireAt: justBefore,
+    accessToken: expiredAccessToken,
+    refreshToken: expiredRefreshToken,
   });
 
   expect(result).toBe('Expire');
 });
 
 test('access token이 만료하지 않은 경우 Use를 반환한다.', () => {
-  const oneSecondAfter = new Date(Date.now() + 1000);
+  const validTime = Math.floor(Date.now() / 1000) + 3600; // 1시간 후 만료
+  const expiredTime = Math.floor(Date.now() / 1000) - 1; // 1초 전 만료
+
+  const validAccessToken = createMockToken(validTime);
+  const expiredRefreshToken = createMockToken(expiredTime);
 
   const result = getTokenState({
-    accessToken: 'access-token',
-    accessTokenExpireAt: oneSecondAfter,
-    refreshToken: 'refresh-token',
-    refreshTokenExpireAt: new Date(),
+    accessToken: validAccessToken,
+    refreshToken: expiredRefreshToken,
   });
 
   expect(result).toBe('Use');
 });
 
 test('access token이 만료했지만 refresh Token이 만료하지 않은 경우 Refresh를 반환한다.', () => {
-  const justBefore = new Date(Date.now() - 1);
-  const oneSecondAfter = new Date(Date.now() + 1000);
+  const expiredTime = Math.floor(Date.now() / 1000) - 1; // 1초 전 만료
+  const validTime = Math.floor(Date.now() / 1000) + 3600; // 1시간 후 만료
+
+  const expiredAccessToken = createMockToken(expiredTime);
+  const validRefreshToken = createMockToken(validTime);
 
   const result = getTokenState({
-    accessToken: 'access-token',
-    accessTokenExpireAt: justBefore,
-    refreshToken: 'refresh-token',
-    refreshTokenExpireAt: oneSecondAfter,
+    accessToken: expiredAccessToken,
+    refreshToken: validRefreshToken,
   });
 
   expect(result).toBe('Refresh');

--- a/app/service/auth.service.ts
+++ b/app/service/auth.service.ts
@@ -1,20 +1,42 @@
 import {AuthTokens, TokenState} from '../types/auth.type';
 
+// JWT 페이로드 디코딩 (exp 클레임 추출)
+const decodeJWTPayload = (token: string): {exp?: number} => {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return {};
+    }
+
+    // Base64Url 디코딩
+    const payload = parts[1];
+    const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(decoded);
+  } catch {
+    return {};
+  }
+};
+
 export const getTokenState = (auth: AuthTokens): TokenState => {
   if (!auth || !auth.accessToken) {
     return 'Expire';
   }
 
-  const accessTokenExpireAt = auth.accessTokenExpireAt.getTime();
-  const refreshTokenExpireAt = auth.refreshTokenExpireAt.getTime();
-  const current = Date.now();
+  const currentTimeSeconds = Math.floor(Date.now() / 1000);
 
-  const isAccessTokenUse = accessTokenExpireAt >= current;
-  const isRefreshTokenUse = refreshTokenExpireAt >= current;
+  // JWT의 exp 클레임 사용 (더 정확하고 timezone 문제 없음)
+  const accessPayload = decodeJWTPayload(auth.accessToken);
+  const refreshPayload = decodeJWTPayload(auth.refreshToken);
 
-  if (isAccessTokenUse) {
+  const accessTokenExpireTime = accessPayload.exp || 0;
+  const refreshTokenExpireTime = refreshPayload.exp || 0;
+
+  const isAccessTokenValid = accessTokenExpireTime > currentTimeSeconds;
+  const isRefreshTokenValid = refreshTokenExpireTime > currentTimeSeconds;
+
+  if (isAccessTokenValid) {
     return 'Use';
-  } else if (isRefreshTokenUse) {
+  } else if (isRefreshTokenValid) {
     return 'Refresh';
   } else {
     return 'Expire';

--- a/app/service/hooks/login.hook.ts
+++ b/app/service/hooks/login.hook.ts
@@ -30,11 +30,7 @@ export const useLoginResponseHandler = (option?: Option) => {
     const {user, tokens, hero} = loginResponse;
 
     setUser(user);
-    setAuthTokens({
-      ...tokens,
-      accessTokenExpireAt: new Date(tokens.accessTokenExpireAt),
-      refreshTokenExpireAt: new Date(tokens.refreshTokenExpireAt),
-    });
+    setAuthTokens(tokens);
     setHero(hero);
     resetShareKey();
 

--- a/app/service/hooks/network.hook.ts
+++ b/app/service/hooks/network.hook.ts
@@ -54,7 +54,6 @@ export const useAxios = <R>({
     if (disableInitialRequest) {
       return;
     }
-    console.log(requestOption.data);
     fetchData(requestOption);
   }, []);
 

--- a/app/types/auth.type.ts
+++ b/app/types/auth.type.ts
@@ -1,8 +1,6 @@
 export type AuthTokens = {
   accessToken: string;
-  accessTokenExpireAt: Date;
   refreshToken: string;
-  refreshTokenExpireAt: Date;
   socialToken?: string;
 };
 


### PR DESCRIPTION
작업 배경

- JWT 토큰의 만료 시간을 서버에서 내려주는 날짜 문자열로 처리하던 방식에서 타임존 문제 발생
- accessTokenExpireAt, refreshTokenExpireAt 필드가 타임존에 따라 정확하지 않은 만료 시간 판단

작업 내용

- AuthTokens 타입에서 accessTokenExpireAt, refreshTokenExpireAt 필드 제거
- JWT 토큰의 exp 클레임을 직접 디코딩하여 만료 시간 확인하는 방식으로 변경
- Base64Url 디코딩을 통한 JWT 페이로드 파싱 로직 추가
- getTokenState 함수를 JWT exp 클레임 기반으로 리팩토링
- 관련 테스트 코드를 JWT 기반 Mock 토큰으로 변경
- 사용하지 않는 함수 및 불필요한 console.log 제거

참고 사항

- JWT의 exp 클레임은 Unix timestamp로 UTC 기준이므로 타임존 문제가 없음
- JWT 디코딩은 네트워크 호출이 아닌 로컬 계산으로 성능 오버헤드 최소
- 기존 테스트 모두 통과하며 토큰 처리 로직 정확성 향상