### PR TITLE
[SHIP] build: 앱 스토어 배포를 위한 버전 업데이트 (v1.2.1)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,8 +84,8 @@ android {
         applicationId "io.itmca.lifepuzzle"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "1.2.0"
+        versionCode 21
+        versionName "1.2.1"
         resValue "string", "kakao_app_key", "${project.env.get("KAKAO_NATIVE_APP_KEY")}"
         manifestPlaceholders = [
                 KAKAO_NATIVE_APP_KEY: project.env.get("KAKAO_NATIVE_APP_KEY")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
@@ -7,6 +8,9 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+    <!-- Google Play Store에 광고 ID를 사용하지 않음을 명시적으로 선언 -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
       android:name="io.itmca.lifepuzzle.MainApplication"

--- a/ios/lifepuzzle.xcodeproj/project.pbxproj
+++ b/ios/lifepuzzle.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		A66B61C42E71BDF700273F94 /* Exceptions for "LifePuzzleShare" folder in "LifePuzzleShare" target */ = {
+		A66B61C42E71BDF700273F94 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -137,18 +137,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		A66B61B72E71BDF700273F94 /* LifePuzzleShare */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				A66B61C42E71BDF700273F94 /* Exceptions for "LifePuzzleShare" folder in "LifePuzzleShare" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = LifePuzzleShare;
-			sourceTree = "<group>";
-		};
+		A66B61B72E71BDF700273F94 /* LifePuzzleShare */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A66B61C42E71BDF700273F94 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LifePuzzleShare; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -553,7 +542,7 @@
 				CODE_SIGN_ENTITLEMENTS = lifepuzzle/lifepuzzle.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N58TUAY7X8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = lifepuzzle/Info.plist;
@@ -562,7 +551,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -593,7 +582,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N58TUAY7X8;
 				INFOPLIST_FILE = lifepuzzle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -601,7 +590,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -692,10 +681,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -770,10 +756,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;


### PR DESCRIPTION
## 작업 배경

- 앱 스토어 배포를 위한 버전 업데이트 및 정책 준수 작업
- Google Play Store 정책에 맞춘 광고 ID 권한 정리

## 작업 내용

- **Android 버전 업데이트**: versionCode 19 → 21, versionName 1.2.0 → 1.2.1
- **iOS 버전 업데이트**: MARKETING_VERSION 1.2.0 → 1.2.1, CURRENT_PROJECT_VERSION 18 → 1
- **Android 광고 ID 권한 제거**: Google Play Store 정책 준수를 위해 AD_ID 권한 명시적 제거
- **iOS 프로젝트 설정 최적화**: 빌드 설정 정리 및 최적화

## 참고 사항

- 기존 테스트 모두 통과 확인 완료
- 앱 스토어 배포 전 Android/iOS 빌드 테스트 필요
- 광고 ID 권한 제거로 인한 기능 영향 없음 (광고 기능 미사용)

🤖 Generated with [Claude Code](https://claude.ai/code)