### PR TITLE
Fix infinite retry on API request failure

### DIFF
--- a/app/services/core/auth-mutation.hook.ts
+++ b/app/services/core/auth-mutation.hook.ts
@@ -50,7 +50,7 @@ export const useAuthMutation = <TData>({
   const trigger = useCallback(
     (overrideConfig: Partial<AxiosRequestConfig> = {}) =>
       mutation.mutateAsync(overrideConfig),
-    [mutation],
+    [mutation.mutateAsync],
   );
 
   return [mutation.isPending, trigger];

--- a/app/services/core/http-mutation.hook.ts
+++ b/app/services/core/http-mutation.hook.ts
@@ -46,7 +46,7 @@ export const useHttpMutation = <TData>({
   const trigger = useCallback(
     (overrideConfig: Partial<AxiosRequestConfig> = {}) =>
       mutation.mutateAsync(overrideConfig),
-    [mutation],
+    [mutation.mutateAsync],
   );
 
   return [mutation.isPending, trigger];


### PR DESCRIPTION
## 작업 배경

- 카카오 로그인 실패 시 (특히 타임아웃) 무한 재시도가 발생하는 현상

## 작업 내용

- `useHttpMutation`과 `useAuthMutation` 훅의 `trigger` 함수 의존성 수정

### 문제 원인
`useCallback`의 의존성이 `[mutation]`으로 설정되어 있었는데, `useMutation`이 반환하는 객체는 요청 상태(`isPending` 등)가 변경될 때마다 새로운 참조가 생성됩니다.

이로 인해 `KaKaoSocialLoginButton`의 `useEffect`에서:
1. `kakaoLogin()` 호출 → 요청 시작
2. `mutation` 상태 변경 → `trigger` 함수 새로 생성
3. `kakaoLogin` 참조 변경 → `useEffect` 재실행
4. 또 `kakaoLogin()` 호출 → **무한 루프**

### 해결 방법
의존성을 `[mutation]` → `[mutation.mutateAsync]`로 변경하여 안정적인 함수 참조 유지

## 참고 사항

- 수정된 파일: `http-mutation.hook.ts`, `auth-mutation.hook.ts`
- 모든 테스트 통과

🤖 Generated with [Claude Code](https://claude.ai/code)